### PR TITLE
Message Timeout

### DIFF
--- a/messageReceiver.sol
+++ b/messageReceiver.sol
@@ -50,7 +50,7 @@ contract UniswapWormholeMessageReceiver {
         // Ensure that the sequence field in the VAA is strictly monotonically increasing
         require(lastExecutedSequence < vm.sequence , "Invalid Sequence number");
         // increment lastExecutedSequence
-        lastExecutedSequence += 1;
+        lastExecutedSequence = vm.sequence;
 
         // check if the message is still valid as defined by the validity period
         require(vm.timestamp + msgValidityPeriod <= block.timestamp, "Message no longer valid");


### PR DESCRIPTION
This PR adds a check to see if the a message has timed out and also has a valid sequence number.

A message is considered to be still valid and not expired if the the current blocktime is within a defined validity period from the message being published in the source chain. The validity period can be set in the constructor.

Sequence numbers need to be strictly monotonically increasing to be considered valid.