### PR TITLE
evm: add multi-step ownership transfer process

### DIFF
--- a/src/UniswapWormholeMessageReceiver.sol
+++ b/src/UniswapWormholeMessageReceiver.sol
@@ -56,11 +56,15 @@ contract UniswapWormholeMessageReceiver {
     uint256 public constant MESSAGE_TIME_OUT_SECONDS = 2 days;
 
     /**
-     * @param bridgeAddress Address of Wormhole bridge contract on this chain.
-     * @param _messageSender // address of the UniswapWormholeMessageSender contract on ethereum in Wormhole format, i.e. 12 zero bytes followed by a 20-byte Ethereum address
+     * @param wormholeAddress Address of Wormhole core messaging contract on this chain.
+     * @param _messageSender Address of the UniswapWormholeMessageSender contract on ethereum in Wormhole format, i.e. 12 zero bytes followed by a 20-byte Ethereum address
      */
-    constructor(address bridgeAddress, bytes32 _messageSender) {
-        wormhole = IWormhole(bridgeAddress);
+    constructor(address wormholeAddress, bytes32 _messageSender) {
+        // sanity check constructor args
+        require(wormholeAddress != address(0), "invalid wormhole address");
+        require(_messageSender != bytes32(0) && bytes12(_messageSender) == 0, "invalid sender contract");
+
+        wormhole = IWormhole(wormholeAddress);
         messageSender = _messageSender;
     }
 

--- a/src/UniswapWormholeMessageSender.sol
+++ b/src/UniswapWormholeMessageSender.sol
@@ -21,8 +21,14 @@ interface IWormhole {
 
 contract UniswapWormholeMessageSender {
     string public constant NAME = "Uniswap Wormhole Message Sender";
+
+    // address of the permissioned message sender
     address public owner;
 
+    // intermediate state when transfering contract ownership
+    address public pendingOwner;
+
+    // consistencyLevel = 1 means finalized on Ethereum, see https://book.wormhole.com/wormhole/3_coreLayerContracts.html#consistency-levels
     // `nonce` in Wormhole is a misnomer and can be safely set to a constant value.
     // In the future it could be used to communicate a payload version,
     // but as long as this contract is not upgradable and only sends one message type, it's not needed.
@@ -44,16 +50,14 @@ contract UniswapWormholeMessageSender {
     IWormhole private immutable wormhole;
 
     /**
-     * @param bridgeAddress Address of Wormhole bridge contract on this chain.
+     * @param wormholeAddress Address of Wormhole core messaging contract on this chain.
      */
-    constructor(address bridgeAddress) {
-        wormhole = IWormhole(bridgeAddress);
-        owner = msg.sender;
-    }
+    constructor(address wormholeAddress) {
+        // sanity check constructor args
+        require(wormholeAddress != address(0), "invalid wormhole address");
 
-    modifier onlyOwner() {
-        require(msg.sender == owner, "sender not owner");
-        _;
+        wormhole = IWormhole(wormholeAddress);
+        owner = msg.sender;
     }
 
     /**
@@ -80,9 +84,39 @@ contract UniswapWormholeMessageSender {
     }
 
     /**
-     * @param newOwner address of new owner contract or EOA
+     * @notice Starts process of transferring ownership of the contract. It saves
+     * the caller's address in the `pendingOwner` state variable.
+     * @param newOwner Address of the `pendingOwner`.
      */
-    function setOwner(address newOwner) external onlyOwner {
-        owner = newOwner;
+    function submitOwnershipTransferRequest(address newOwner) public onlyOwner {
+        require(newOwner != address(0), "newOwner cannot equal address(0)");
+
+        pendingOwner = newOwner;
+    }
+
+    /**
+     * @notice Cancels the ownership transfer process.
+     * @dev Sets the `pendingOwner` state variable to the zero address.
+     */
+    function cancelOwnershipTransferRequest() public onlyOwner {
+        pendingOwner = address(0);
+    }
+
+    /**
+     * @notice Transfers ownership of the contract to the `pendingOwner`.
+     * @dev It updates the `owner` state variable with the `pendingOwner` state
+     * variable after validating that the caller is the `pendingOwner`.
+     */
+    function confirmOwnershipTransferRequest() public {
+        require(msg.sender == pendingOwner, "caller must be pendingOwner");
+
+        // update the owner in the contract state and reset the pending owner
+        owner = pendingOwner;
+        pendingOwner = address(0);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "sender not owner");
+        _;
     }
 }

--- a/src/interfaces/IUniswapWormholeMessageSender.sol
+++ b/src/interfaces/IUniswapWormholeMessageSender.sol
@@ -5,4 +5,9 @@ pragma solidity ^0.8.9;
 
 interface IUniswapWormholeMessageSender {
     function sendMessage(address[] memory targets, uint256[] memory values, bytes[] memory datas, address messageReceiver, uint16 receiverChainId) external payable;
+    function owner() external returns (address);
+    function pendingOwner() external returns (address);
+    function submitOwnershipTransferRequest(address newOwner) external;
+    function cancelOwnershipTransferRequest() external;
+    function confirmOwnershipTransferRequest() external;
 }

--- a/test/UniswapWormholeMessageSenderReceiver.t.sol
+++ b/test/UniswapWormholeMessageSenderReceiver.t.sol
@@ -13,7 +13,6 @@ import "wormhole/contracts/Setup.sol";
 import {Wormhole} from "wormhole/contracts/Wormhole.sol";
 
 contract UniswapWormholeMessageSenderReceiverTest is Test {
-
     IWormhole public wormhole;
     IUniswapWormholeMessageReceiver public uniReceiver;
     IUniswapWormholeMessageSender public uniSender;
@@ -301,5 +300,113 @@ contract UniswapWormholeMessageSenderReceiverTest is Test {
         uniReceiver.receiveMessage(whMessage);
     }
 
+    function testSubmitOwnershipTransferRequest(address newOwner) public {
+        vm.assume(newOwner != address(0));
 
+        // call `submitOwnershipTransferRequest`
+        uniSender.submitOwnershipTransferRequest(newOwner);
+
+        // confirm state changes
+        assertEq(uniSender.pendingOwner(), newOwner);
+    }
+
+    function testSubmitOwnershipTransferRequestFailureZeroAddress() public {
+        address newOwner = address(0);
+
+        // expect the `submitOwnershipTransferRequest` call to revert
+        vm.expectRevert("newOwner cannot equal address(0)");
+        uniSender.submitOwnershipTransferRequest(newOwner);
+    }
+
+    function testSubmitOwnershipTransferRequestFailureOwnerOnly() public {
+        address newOwner = address(this);
+
+        // prank the caller's address
+        vm.prank(makeAddr("notTheOwner"));
+
+        // expect the `submitOwnershipTransferRequest` call to revert
+        vm.expectRevert("sender not owner");
+        uniSender.submitOwnershipTransferRequest(newOwner);
+    }
+
+    function testCancelOwnershipTransferRequest(address newOwner) public {
+        vm.assume(newOwner != address(this) && newOwner != address(0));
+
+        // set the pendingOwner
+        uniSender.submitOwnershipTransferRequest(newOwner);
+        assertEq(uniSender.pendingOwner(), newOwner);
+
+        // cancel the request to change ownership of the contract
+        uniSender.cancelOwnershipTransferRequest();
+
+        // confirm that the pendingOwner was set to the zero address
+        assertEq(uniSender.pendingOwner(), address(0));
+
+        // prank
+        vm.prank(makeAddr("notTheOwner"));
+
+        // expect the confirmOwnershipTransferRequest call to revert
+        vm.expectRevert("caller must be pendingOwner");
+        uniSender.confirmOwnershipTransferRequest();
+    }
+
+    function testCancelOwnershipTransferRequestOwnerOnly() public {
+        address wallet = makeAddr("wallet");
+
+        // set the pendingOwner
+        uniSender.submitOwnershipTransferRequest(wallet);
+
+        // prank
+        vm.prank(wallet);
+
+        // expect the cancelOwnershipTransferRequest call to revert
+        vm.expectRevert("sender not owner");
+        uniSender.cancelOwnershipTransferRequest();
+
+        // confirm pendingOwner is still set to address(this)
+        assertEq(uniSender.pendingOwner(), wallet);
+    }
+
+    function testConfirmOwnershipTransferRequest(address newOwner) public {
+        vm.assume(newOwner != address(0));
+
+        // verify pendingOwner and owner state variables
+        assertEq(uniSender.pendingOwner(), address(0));
+        assertEq(uniSender.owner(), address(this));
+
+        // submit ownership transfer request
+        uniSender.submitOwnershipTransferRequest(newOwner);
+
+        // verify the pendingOwner state variable
+        assertEq(uniSender.pendingOwner(), newOwner);
+
+        // Invoke the confirmOwnershipTransferRequest method from the
+        // new owner's wallet.
+        vm.prank(newOwner);
+        uniSender.confirmOwnershipTransferRequest();
+
+        // Verify the ownership change, and that the pendingOwner
+        // state variable has been set to address(0).
+        assertEq(uniSender.owner(), newOwner);
+        assertEq(uniSender.pendingOwner(), address(0));
+    }
+
+    function testConfirmOwnershipTransferRequestNotPendingOwner(
+        address pendingOwner
+    ) public {
+        vm.assume(
+            pendingOwner != address(0) &&
+            pendingOwner != address(this)
+        );
+
+        // set the pending owner and confirm the pending owner state variable
+        uniSender.submitOwnershipTransferRequest(pendingOwner);
+        assertEq(uniSender.pendingOwner(), pendingOwner);
+
+        // Attempt to confirm the ownership transfer request from a wallet that is
+        // not the pending owner's.
+        vm.prank(address(this));
+        vm.expectRevert("caller must be pendingOwner");
+        uniSender.confirmOwnershipTransferRequest();
+    }
 }


### PR DESCRIPTION
The purpose of this PR is to add a multi-step ownership transfer process to the `UniswapWormholeMessageSender` contract. 