### PR TITLE
Add target value check and integration test

### DIFF
--- a/src/UniswapWormholeMessageReceiver.sol
+++ b/src/UniswapWormholeMessageReceiver.sol
@@ -80,7 +80,7 @@ contract UniswapWormholeMessageReceiver {
     /**
      * @param whMessage Wormhole message relayed from a source chain.
      */
-    function receiveMessage(bytes calldata whMessage) public {
+    function receiveMessage(bytes calldata whMessage) public payable {
         (Structs.VM memory vm, bool valid, string memory reason) = wormhole.parseAndVerifyVM(whMessage);
 
         // validate

--- a/src/UniswapWormholeMessageSender.sol
+++ b/src/UniswapWormholeMessageSender.sol
@@ -60,7 +60,7 @@ contract UniswapWormholeMessageSender {
      */
     constructor(address wormholeAddress) {
         // sanity check constructor args
-        require(wormholeAddress != address(0), "invalid wormhole address");
+        require(wormholeAddress != address(0), "Invalid wormhole address");
 
         wormhole = IWormhole(wormholeAddress);
         owner = msg.sender;

--- a/src/interfaces/IUniswapWormholeMessageReceiver.sol
+++ b/src/interfaces/IUniswapWormholeMessageReceiver.sol
@@ -36,5 +36,5 @@ interface IUniswapWormholeMessageReceiver {
         bytes32 hash;
     }
 
-    function receiveMessage(bytes memory whMessage) external;
+    function receiveMessage(bytes memory whMessage) external payable;
 }

--- a/test/MockGovernanceReceiver.sol
+++ b/test/MockGovernanceReceiver.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+contract MockGovernanceReceiver {
+    address trustedCaller;
+
+    // governance action values
+    uint256 public constant governanceValueOne = 1e13;
+    uint256 public constant governanceValueTwo = 1e17;
+
+    mapping(bytes32 => bool) public consumedActions;
+
+    constructor(address _trustedCaller) {
+        require(_trustedCaller != address(0), "invalid caller address");
+
+        trustedCaller = _trustedCaller;
+    }
+
+    function receiveGovernanceMessageOne(bytes32 governanceAction, uint8 governanceType) public payable {
+        require(governanceType == 1, "invalid governance type");
+        require(msg.sender == trustedCaller, "unknown caller");
+        require(!consumedActions[governanceAction], "action already consumed");
+        require(msg.value == governanceValueOne, "not enough value");
+
+        consumedActions[governanceAction] = true;
+    }
+
+    function receiveGovernanceMessageTwo(bytes32 governanceAction, uint8 governanceType) public payable {
+        require(governanceType == 2, "invalid governance type");
+        require(msg.sender == trustedCaller, "unknown caller");
+        require(!consumedActions[governanceAction], "action already consumed");
+        require(msg.value == governanceValueTwo, "not enough value");
+
+        consumedActions[governanceAction] = true;
+    }
+}

--- a/test/UniswapWormholeMessageSenderReceiver.t.sol
+++ b/test/UniswapWormholeMessageSenderReceiver.t.sol
@@ -59,11 +59,8 @@ contract UniswapWormholeMessageSenderReceiverTest is Test {
         uniSender = IUniswapWormholeMessageSender(uniSenderAddress);
 
         // create calldata for the first mock governance action
-        bytes memory encodedGovernanceActionOne = abi.encodeWithSignature(
-            "receiveGovernanceMessageOne(bytes32,uint8)",
-            governanceActionOne,
-            1
-        );
+        bytes memory encodedGovernanceActionOne =
+            abi.encodeWithSignature("receiveGovernanceMessageOne(bytes32,uint8)", governanceActionOne, 1);
 
         targets.push(mockReceiver);
         values.push(mock.governanceValueOne());
@@ -93,6 +90,30 @@ contract UniswapWormholeMessageSenderReceiverTest is Test {
             block.chainid // evm chain Id
         );
         return address(wormholeAddress);
+    }
+
+    function expectRevertWithValue(
+        address contractAddress,
+        bytes memory encodedSignature,
+        string memory expectedRevert,
+        uint256 value_
+    ) internal {
+        (bool success, bytes memory result) = contractAddress.call{value: value_}(encodedSignature);
+        require(!success, "call did not revert");
+
+        // fetch the revert string bytes
+        bytes memory newResult;
+        for (uint256 i = 0; i < result.length; ++i) {
+            // skip signature
+            if (i > 3) {
+                newResult = abi.encodePacked(newResult, result[i]);
+            }
+        }
+
+        // compare revert strings
+        bytes32 expectedRevertHash = keccak256(abi.encode(expectedRevert));
+        bytes32 actualRevertHash = keccak256(newResult);
+        require(expectedRevertHash == actualRevertHash, "call did not revert as expected");
     }
 
     function simulateSignedVaa(bytes memory body, bytes32 _hash) internal returns (bytes memory vaa) {
@@ -231,11 +252,8 @@ contract UniswapWormholeMessageSenderReceiverTest is Test {
 
     function testReceiveMessageSuccessWithTwoActions() public {
         // create second governance action signature
-        bytes memory encodedGovernanceActionTwo = abi.encodeWithSignature(
-            "receiveGovernanceMessageTwo(bytes32,uint8)",
-            governanceActionTwo,
-            2
-        );
+        bytes memory encodedGovernanceActionTwo =
+            abi.encodeWithSignature("receiveGovernanceMessageTwo(bytes32,uint8)", governanceActionTwo, 2);
 
         // create local instance of targets/values/datas arrays
         address[] memory _targets = new address[](2);
@@ -265,6 +283,75 @@ contract UniswapWormholeMessageSenderReceiverTest is Test {
         // confirm that the mock contract received the governance action
         assertEq(mock.consumedActions(governanceActionOne), true);
         assertEq(mock.consumedActions(governanceActionTwo), true);
+    }
+
+    function testInvalidSubCall() public {
+        uint64 sequence = 1;
+        uint16 emitterChainId = 2;
+
+        // create bad datas array
+        bytes[] memory badDatas = new bytes[](1);
+        badDatas[0] = abi.encodeWithSignature("receiveGovernanceMessageOne(bytes32,uint8)", governanceActionOne, 420); // bad action
+
+        bytes memory payload = generateMessagePayload(targets, values, badDatas, bsc_chain_id, address(uniReceiver));
+        bytes memory whMessage = generateSignedVaa(emitterChainId, msgSender, sequence, payload);
+
+        vm.warp(timestamp + 45 minutes);
+
+        // note Sometimes forge cannot correctly match the revert string from a call. The
+        // expectRevertWithValue performs the same function as vm.expectRevert.
+        bytes memory encodedSignature = abi.encodeWithSignature("receiveMessage(bytes)", whMessage);
+        expectRevertWithValue(address(uniReceiver), encodedSignature, "Sub-call failed", mock.governanceValueOne());
+
+        // confirm that the mock contract did not receive the governance action
+        assertEq(mock.consumedActions(governanceActionOne), false);
+    }
+
+    function testIncorrectValueWithOneAction(uint256 _value) public {
+        vm.assume(_value != mock.governanceValueOne() && _value < type(uint96).max);
+
+        uint64 sequence = 1;
+        uint16 emitterChainId = 2;
+
+        bytes memory payload = generateMessagePayload(targets, values, datas, bsc_chain_id, address(uniReceiver));
+        bytes memory whMessage = generateSignedVaa(emitterChainId, msgSender, sequence, payload);
+
+        vm.warp(timestamp + 45 minutes);
+        vm.expectRevert("Incorrect value");
+        uniReceiver.receiveMessage{value: _value}(whMessage);
+    }
+
+    function testIncorrectValueWithTwoActions(uint256 _value) public {
+        vm.assume(_value != mock.governanceValueOne() + mock.governanceValueTwo() && _value < type(uint96).max);
+
+        // create second governance action signature
+        bytes memory encodedGovernanceActionTwo =
+            abi.encodeWithSignature("receiveGovernanceMessageTwo(bytes32,uint8)", governanceActionTwo, 2);
+
+        // create local instance of targets/values/datas arrays
+        address[] memory _targets = new address[](2);
+        uint256[] memory _values = new uint256[](2);
+        bytes[] memory _datas = new bytes[](2);
+
+        // update the local arrays with the first governance action
+        _targets[0] = targets[0];
+        _values[0] = values[0];
+        _datas[0] = datas[0];
+
+        // update the local arrays with the second governance action
+        _targets[1] = address(mock);
+        _values[1] = mock.governanceValueTwo();
+        _datas[1] = encodedGovernanceActionTwo;
+
+        // other test variables
+        uint64 sequence = 1;
+        uint16 emitterChainId = 2;
+        bytes memory payload = generateMessagePayload(_targets, _values, _datas, bsc_chain_id, address(uniReceiver));
+        bytes memory whMessage = generateSignedVaa(emitterChainId, msgSender, sequence, payload);
+
+        vm.warp(timestamp + 45 minutes);
+        vm.expectRevert("Incorrect value");
+        uniReceiver.receiveMessage{value: _value}(whMessage);
     }
 
     function testInvalidEmitterAddress() public {
@@ -359,21 +446,6 @@ contract UniswapWormholeMessageSenderReceiverTest is Test {
 
         vm.warp(timestamp + 45 minutes);
         vm.expectRevert("Message not for this chain");
-        uniReceiver.receiveMessage(whMessage);
-    }
-
-    function testFailingSubcall() public {
-        uint64 sequence = 2;
-
-        address[] memory failingTargets = new address[](1);
-        failingTargets[0] = 0xb4c79daB8f259C7Aee6E5b2Aa729821864227e84;
-
-        bytes memory payload =
-            generateMessagePayload(failingTargets, values, datas, bsc_chain_id - 1, address(uniReceiver));
-        bytes memory whMessage = generateSignedVaa(ethereum_chain_id, msgSender, sequence, payload);
-
-        vm.warp(timestamp + 45 minutes);
-        vm.expectRevert("Sub-call failed");
         uniReceiver.receiveMessage(whMessage);
     }
 


### PR DESCRIPTION
The purpose of this PR is to add a mock governance receiver contract to validate input data from the `UniswapWormholeMessageReceiver` contract. This PR also adds a check to verify that the relayer passed enough value to complete the governance calls to the target contracts. 